### PR TITLE
Using stdio ignore instead of null

### DIFF
--- a/src/npmInstall.ts
+++ b/src/npmInstall.ts
@@ -2,7 +2,7 @@ const cs: any = require('cross-spawn');
 
 export default async function () {
 	return new Promise((resolve, reject) => {
-		cs.spawn('npm', ['install'], { stdio: null })
+		cs.spawn('npm', ['install'], { stdio: 'ignore' })
 			.on('close', resolve)
 			.on('error', (err: Error) => {
 				reject(err);


### PR DESCRIPTION
npm install phase of `create-app` was hanging, an incorrect value was being passed to `stdio`
