### PR TITLE
Fix help so it displays per grouping

### DIFF
--- a/src/register.ts
+++ b/src/register.ts
@@ -1,13 +1,8 @@
-import { Helper } from '@dojo/cli/interfaces';
-import { Yargs } from 'yargs';
-
-export default function(helper: Helper): Yargs {
-	helper.yargs.option('n', {
+export default function(options: (key: string, options: Options) => void): void {
+	options('n', {
 		alias: 'name',
 		describe: 'The name of your application',
 		demand: true,
 		type: 'string'
 	});
-
-	return helper.yargs;
 }

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,4 +1,4 @@
-import { OptionsHelper } from 'dojo-cli/interfaces';
+import { OptionsHelper } from '@dojo/cli/interfaces';
 
 export default function(options: OptionsHelper): void {
 	options('n', {

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,4 +1,6 @@
-export default function(options: (key: string, options: Options) => void): void {
+import { Helper, OptionsHelper } from 'dojo-cli/interfaces';
+
+export default function(helper: Helper, options: OptionsHelper): void {
 	options('n', {
 		alias: 'name',
 		describe: 'The name of your application',

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,6 +1,6 @@
-import { Helper, OptionsHelper } from 'dojo-cli/interfaces';
+import { OptionsHelper } from 'dojo-cli/interfaces';
 
-export default function(helper: Helper, options: OptionsHelper): void {
+export default function(options: OptionsHelper): void {
 	options('n', {
 		alias: 'name',
 		describe: 'The name of your application',

--- a/tests/unit/register.ts
+++ b/tests/unit/register.ts
@@ -2,7 +2,6 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import register from './../../src/register';
 import * as sinon from 'sinon';
-import { getHelperStub } from '../support/testHelper';
 
 let sandbox: sinon.SinonSandbox;
 
@@ -16,13 +15,13 @@ registerSuite({
 	},
 	'Should add a yargs option for name'() {
 		const options = sandbox.stub();
-		register(getHelperStub<any>(), options);
+		register(options);
 		assert.isTrue(options.calledOnce);
 		assert.isTrue(options.firstCall.calledWithMatch('n', { 'alias': 'name' }));
 	},
 	'Should demand the name option'() {
 		const options = sandbox.stub();
-		register(getHelperStub<any>(), options);
+		register(options);
 		assert.isTrue(options.firstCall.calledWithMatch('n', { 'demand': true }));
 	}
 });

--- a/tests/unit/register.ts
+++ b/tests/unit/register.ts
@@ -2,6 +2,7 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import register from './../../src/register';
 import * as sinon from 'sinon';
+import { getHelperStub } from '../support/testHelper';
 
 let sandbox: sinon.SinonSandbox;
 
@@ -15,13 +16,13 @@ registerSuite({
 	},
 	'Should add a yargs option for name'() {
 		const options = sandbox.stub();
-		register(options);
+		register(getHelperStub<any>(), options);
 		assert.isTrue(options.calledOnce);
 		assert.isTrue(options.firstCall.calledWithMatch('n', { 'alias': 'name' }));
 	},
 	'Should demand the name option'() {
 		const options = sandbox.stub();
-		register(options);
+		register(getHelperStub<any>(), options);
 		assert.isTrue(options.firstCall.calledWithMatch('n', { 'demand': true }));
 	}
 });

--- a/tests/unit/register.ts
+++ b/tests/unit/register.ts
@@ -1,29 +1,27 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import register from './../../src/register';
-import { getHelperStub } from '../support/testHelper';
-import { Helper } from '@dojo/cli/interfaces';
-import { SinonStub, stub } from 'sinon';
+import * as sinon from 'sinon';
 
-let helperStub: Helper;
-let optionStub: SinonStub;
+let sandbox: sinon.SinonSandbox;
 
 registerSuite({
 	name: 'register',
 	'beforeEach'() {
-		helperStub = getHelperStub<any>();
-		optionStub = stub(helperStub.yargs, 'option');
+		sandbox = sinon.sandbox.create();
 	},
 	'afterEach'() {
-		optionStub.restore();
+		sandbox.restore();
 	},
 	'Should add a yargs option for name'() {
-		register(helperStub);
-		assert.isTrue(optionStub.calledOnce);
-		assert.isTrue(optionStub.firstCall.calledWithMatch('n', { 'alias': 'name' }));
+		const options = sandbox.stub();
+		register(options);
+		assert.isTrue(options.calledOnce);
+		assert.isTrue(options.firstCall.calledWithMatch('n', { 'alias': 'name' }));
 	},
 	'Should demand the name option'() {
-		register(helperStub);
-		assert.isTrue(optionStub.firstCall.calledWithMatch('n', { 'demand': true }));
+		const options = sandbox.stub();
+		register(options);
+		assert.isTrue(options.firstCall.calledWithMatch('n', { 'demand': true }));
 	}
 });


### PR DESCRIPTION
<!--
Thank you for Contributing to Dojo 2.

Please make sure you have read our Contributing Guidelines
available at: https://github.com/dojo/meta/blob/master/CONTRIBUTING.md
before submitting a PR.

-->

**Type:** bug

**Description:** 

Fix help display so that it displays options per grouping

**Related Issue:** #58

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] The code passes the CI tests
* [x] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged