### PR TITLE
Add decorator config

### DIFF
--- a/src/templates/tsconfig.json
+++ b/src/templates/tsconfig.json
@@ -1,15 +1,17 @@
 {
 	"compilerOptions": {
 		"declaration": false,
+		"emitDecoratorMetadata": true,
+		"experimentalDecorators": true,
 		"module": "umd",
+		"moduleResolution": "node",
 		"noImplicitAny": true,
 		"noImplicitThis": true,
-		"strictNullChecks": true,
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,
-		"target": "es5",
-		"moduleResolution": "node"
+		"strictNullChecks": true,
+		"target": "es5"
 	},
 	"include": [
 		"./typings/index.d.ts",


### PR DESCRIPTION
widget-core 2.0.0-alpha.24+ requires experimental decorators config.