### PR TITLE
Captures more error scenarios for `npm install`.

### DIFF
--- a/src/npmInstall.ts
+++ b/src/npmInstall.ts
@@ -10,9 +10,14 @@ export default async function () {
 			text: 'npm install'
 		}).start();
 		cs.spawn('npm', ['install'], { stdio: 'ignore' })
-			.on('close', () => {
-				spinner.stopAndPersist(green.bold(' completed'));
-				resolve();
+			.on('exit', function(code: Number){
+				if (code !== 0) {
+					spinner.stopAndPersist(red.bold(' failed'));
+					reject(new Error(`exit code: ${code}`));
+				} else {
+					spinner.stopAndPersist(green.bold(' completed'));
+					resolve();
+				}
 			})
 			.on('error', (err: Error) => {
 				spinner.stopAndPersist(red.bold(' failed'));

--- a/tests/unit/npmInstall.ts
+++ b/tests/unit/npmInstall.ts
@@ -45,12 +45,12 @@ registerSuite({
 		spawnStub.restore();
 	},
 	async 'Should call spawn to run an npm process'() {
-		spawnOnStub.onFirstCall().callsArg(1);
+		spawnOnStub.onFirstCall().callsArgWith(1, 0);
 		await npmInstall.default();
 		assert.isTrue(spawnStub.calledOnce);
 	},
 	async 'Should use a loading spinner'() {
-		spawnOnStub.onFirstCall().callsArg(1);
+		spawnOnStub.onFirstCall().callsArgWith(1, 0);
 		await npmInstall.default();
 		assert.isTrue(startStub.calledOnce, 'Should call start on the spinner');
 		assert.isTrue(stopAndPersistStub.calledOnce, 'Should stop the spinner');
@@ -65,7 +65,21 @@ registerSuite({
 			assert.fail(null, null, 'Should not get here');
 		}
 		catch (error) {
-			assert.equal(errorMessage, error.message);
+			assert.equal(error.message, errorMessage);
+			assert.isTrue(stopAndPersistStub.calledOnce, 'Should stop the spinner');
+			assert.isTrue(stopAndPersistStub.firstCall.calledWithMatch('failed'),
+				'Should persis the failed message');
+		}
+	},
+	async 'Should reject with an error when spawn process returns an exit code !== 0'() {
+		const errorExitCode = 1;
+		spawnOnStub.onFirstCall().callsArgWith(1, errorExitCode);
+		try {
+			await npmInstall.default();
+			assert.fail(null, null, 'Should not get here');
+		}
+		catch (error) {
+			assert.equal(error.message, `exit code: ${errorExitCode}` );
 			assert.isTrue(stopAndPersistStub.calledOnce, 'Should stop the spinner');
 			assert.isTrue(stopAndPersistStub.firstCall.calledWithMatch('failed'),
 				'Should persis the failed message');


### PR DESCRIPTION
**Type:** bug fix

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

It turns out `nodejs` only [treats a spawn process as error when it returns a negative exit code](https://github.com/nodejs/node/blob/master/lib/internal/child_process.js#L187
). In the case of `npm install`, when failing it exits with `1` instead of a negative number. So it is not enough to only rely on [error callback](https://github.com/dojo/cli-create-app/blob/master/src/npmInstall.ts#L17-L20).

Resolves #5 
