### PR TITLE
Add service worker support

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,7 @@ const fileNames = [
 	'src/main.ts',
 	'src/main.css',
 	'src/App.ts',
+	'src/registerServiceWorker.ts',
 	'src/widgets/HelloWorld.ts',
 	'src/widgets/styles/HelloWorld.m.css',
 	'src/widgets/styles/HelloWorld.m.css.d.ts',

--- a/src/templates/src/main.ts
+++ b/src/templates/src/main.ts
@@ -1,5 +1,6 @@
 import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import App from './App';
+import registerServiceWorker from './registerServiceWorker';
 
 const root = document.querySelector('my-app') || undefined;
 
@@ -7,3 +8,4 @@ const Projector = ProjectorMixin(App);
 const projector = new Projector();
 
 projector.append(root);
+registerServiceWorker();

--- a/src/templates/src/registerServiceWorker.ts
+++ b/src/templates/src/registerServiceWorker.ts
@@ -1,0 +1,46 @@
+export default function registerServiceWorker() {
+	if (process.env.DOJO_SERVICE_WORKERS && 'serviceWorker' in navigator) {
+		window.addEventListener('load', () => {
+			// TODO This assumes we're serving from the root. We could provide the public URL as an environment variable
+			const serviceWorkerUrl = `/service-worker.js`;
+			navigator.serviceWorker
+				.register(serviceWorkerUrl)
+				.then((registration: ServiceWorkerRegistration) => {
+					registration.onupdatefound = () => {
+						const installingWorker = registration.installing;
+						if (installingWorker) {
+							installingWorker.onstatechange = () => {
+								if (installingWorker.state === 'installed') {
+									if (navigator.serviceWorker.controller) {
+										// At this point, the old content will have been purged and
+										// the fresh content will have been added to the cache.
+										// It's the perfect time to display a "New content is
+										// available; please refresh." message in your web app.
+										console.log('New content is available; please refresh.');
+									}
+									else {
+										// At this point, everything has been precached.
+										// It's the perfect time to display a
+										// "Content is cached for offline use." message.
+										console.log('Content is cached for offline use.');
+									}
+								}
+							};
+						}
+					};
+				})
+				.catch((error) => {
+					console.error('Error during service worker registration:', error);
+				});
+		});
+	}
+}
+
+export function unregister() {
+	if ('serviceWorker' in navigator) {
+		navigator.serviceWorker.ready.then((registration: ServiceWorkerRegistration) => {
+			registration.unregister();
+		});
+	}
+}
+

--- a/src/templates/src/registerServiceWorker.ts
+++ b/src/templates/src/registerServiceWorker.ts
@@ -43,4 +43,3 @@ export function unregister() {
 		});
 	}
 }
-


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This doesn't resolve any issues but it relates to dojo/meta#169. This adds a module that will register a service worker script at '/service-worker.js' if an appropriate environment variable is set and if service workers are available. Otherwise it does nothing. Providing the service worker script and setting the environment variable are left to cli-build-webpack.

There's a TODO in the file right now, concerning the base path to search for service-worker.js. It has to be at the root in order to cache all files, and right now cli-build-webpack doesn't allow us to specify an alternative output directory, so potentially we can just remove that.
