### PR TITLE
Add meta tags to index.html

### DIFF
--- a/src/templates/src/index.html
+++ b/src/templates/src/index.html
@@ -2,6 +2,8 @@
 <html>
 <head>
 	<title><%= appName %></title>
+	<meta name="theme-color" content="#222127">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
 	<p>Welcome to <%= appName %></p>


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Lighthouse checks for `<meta>` tags that set a theme color(used to color the address bar), and viewport settings, which set the viewport to the width of the device. This adds these features to `index.html` by default. The theme-color used here and in the manifest.json PR is just the color pulled from the header in dojo.io. If there's a better default I can update it here and there.

With all of these PWA PRs, an out of the box dojo 2 app(with service workers turned on via `.dojorc`), scores a 100/100 on the lighthouse PWA rating system
