### PR TITLE
Update to TypeScript 2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "test": "grunt test"
   },
   "devDependencies": {
+    "@dojo/cli": "next",
+    "@dojo/loader": "next",
     "@types/chai": "^3.4.34",
     "@types/chalk": "^0.4.31",
     "@types/ejs": "^2.3.33",
@@ -36,8 +38,6 @@
     "@types/node": "^6.0.49",
     "@types/sinon": "^1.16.32",
     "codecov.io": "0.1.6",
-    "@dojo/cli": "beta1",
-    "@dojo/loader": "next",
     "glob": "^7.0.3",
     "grunt": "~1.0.1",
     "grunt-dojo2": "latest",
@@ -46,7 +46,7 @@
     "mockery": "^1.7.0",
     "remap-istanbul": "^0.6.4",
     "sinon": "^1.17.5",
-    "typescript": "~2.3.2",
+    "typescript": "~2.4.1",
     "yargs": "^5.0.0"
   },
   "dependencies": {

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -2,16 +2,16 @@ import { stub } from 'sinon';
 import * as yargs from 'yargs';
 import { Helper } from '@dojo/cli/interfaces';
 
-export function getHelperStub<T>(): Helper {
+export function getHelperStub(): Helper {
 	return {
-		context: <T> {},
+		context: {},
 		yargs,
 		command: {
 			run: stub().returns(Promise.resolve()),
 			exists: stub().returns(true)
 		},
 		configuration: {
-			save: stub().returns(Promise.resolve()),
+			set: stub().returns(Promise.resolve()),
 			get: stub().returns(Promise.resolve())
 		}
 	};

--- a/tests/unit/run.ts
+++ b/tests/unit/run.ts
@@ -51,7 +51,7 @@ registerSuite({
 		mockery.disable();
 	},
 	'beforeEach'() {
-		helperStub = getHelperStub<any>();
+		helperStub = getHelperStub();
 		existsSyncStub.reset();
 		existsSyncStub.returns(false);
 		createDirStub.reset();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,14 +2,12 @@
 	"compilerOptions": {
 		"declaration": false,
 		"module": "umd",
-		"noImplicitAny": true,
-		"noImplicitThis": true,
-		"strictNullChecks": true,
+		"moduleResolution": "node",
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,
-		"target": "es6",
-		"moduleResolution": "node",
+		"strict": true,
+		"target": "es2016",
 		"types": [ "intern" ]
 	},
 	"include": [


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This PR migrates to TypeScript 2.4 along with the compiler options `strict` and `target = es2016`.  In addition there are a couple minor typing clean ups due to weak type detection.

Refs: dojo/meta#189
