### PR TITLE
Add separate tsconfig for tests and fix a path issue

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ export function getDirectoryNames(appName: string): string[] {
 const fileNames = [
 	'package.json',
 	'tsconfig.json',
+	'tsconfig-tests.json',
 	'.gitignore',
 	'README.md',
 	'src/index.html',

--- a/src/templates/tsconfig-tests.json
+++ b/src/templates/tsconfig-tests.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"include": [
+		"./typings/index.d.ts",
+		"./src/**/*.ts",
+		"./tests/**/*.ts"
+	]
+}

--- a/src/templates/tsconfig.json
+++ b/src/templates/tsconfig.json
@@ -23,7 +23,6 @@
 	},
 	"include": [
 		"./typings/index.d.ts",
-		"./src/**/*.ts",
-		"./tests/**/*.ts"
+		"./src/**/*.ts"
 	]
 }

--- a/tests/unit/config.ts
+++ b/tests/unit/config.ts
@@ -24,7 +24,9 @@ registerSuite({
 		});
 	},
 	'Should strip .template from fileName'() {
-		assert.equal(stripTemplateFromFileName('/foo/bar/.gitignore.template'), '/foo/bar/.gitignore');
+		assert.equal(stripTemplateFromFileName(
+			path.normalize('/foo/bar/.gitignore.template')), path.normalize('/foo/bar/.gitignore'
+		));
 	},
 	'Should return config of file names using the given package path'() {
 		const renderFilesConfig = getRenderFilesConfig(packagePath);


### PR DESCRIPTION

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Along with dojo/cli-build#, addresses dojo/cli-build#113 by creating seprate tsconfig files for compiling `src` or `src` and `tests`.