### PR TITLE
Fixing test failure on Windows

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { join, parse, format, normalize } from 'path';
+import { format, join, normalize, parse  } from 'path';
 
 export function getDirectoryNames(appName: string): string[] {
 	return [

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { join, parse, format } from 'path';
+import { join, parse, format, normalize } from 'path';
 
 export function getDirectoryNames(appName: string): string[] {
 	return [
@@ -38,7 +38,7 @@ const fileNames = [
 export function stripTemplateFromFileName(filePath: string) {
 	const path = parse(filePath);
 	path.base = path.base.replace('.template', '');
-	return format(path);
+	return normalize(format(path));
 }
 
 export function getRenderFilesConfig(packagePath: string): {src: string, dest: string}[] {

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -11,7 +11,7 @@ export function getHelperStub(): Helper {
 			exists: stub().returns(true)
 		},
 		configuration: {
-			set: stub().returns(Promise.resolve()),
+			save: stub().returns(Promise.resolve()),
 			get: stub().returns(Promise.resolve())
 		}
 	};

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -11,7 +11,7 @@ export function getHelperStub(): Helper {
 			exists: stub().returns(true)
 		},
 		configuration: {
-			save: stub().returns(Promise.resolve()),
+			set: stub().returns(Promise.resolve()),
 			get: stub().returns(Promise.resolve())
 		}
 	};

--- a/tests/unit/config.ts
+++ b/tests/unit/config.ts
@@ -24,7 +24,7 @@ registerSuite({
 		});
 	},
 	'Should strip .template from fileName'() {
-		assert.equal(stripTemplateFromFileName('/foo/bar/.gitignore.template'), '/foo/bar/.gitignore');
+		assert.equal(stripTemplateFromFileName('/foo/bar/.gitignore.template'), `/foo/bar${path.sep}.gitignore`);
 	},
 	'Should return config of file names using the given package path'() {
 		const renderFilesConfig = getRenderFilesConfig(packagePath);

--- a/tests/unit/config.ts
+++ b/tests/unit/config.ts
@@ -24,7 +24,7 @@ registerSuite({
 		});
 	},
 	'Should strip .template from fileName'() {
-		assert.equal(stripTemplateFromFileName('/foo/bar/.gitignore.template'), `/foo/bar${path.sep}.gitignore`);
+		assert.equal(stripTemplateFromFileName('/foo/bar/.gitignore.template'), `${path.sep}foo${path.sep}bar${path.sep}.gitignore`);
 	},
 	'Should return config of file names using the given package path'() {
 		const renderFilesConfig = getRenderFilesConfig(packagePath);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixing test failure on Windows.  Path is properly converted to `\\` separator on Windows now.

Resolves #91 
