### PR TITLE
upgrade the templates deps to use 'next'

### DIFF
--- a/src/templates/package.json
+++ b/src/templates/package.json
@@ -2,19 +2,18 @@
   "name": "<%- appName %>",
   "version": "1.0.0",
   "dependencies": {
-    "@dojo/core": "beta1",
-    "@dojo/has": "beta1",
-    "@dojo/routing": "beta1",
-    "@dojo/shim": "beta1",
-    "@dojo/widget-core": "beta1",
-    "@dojo/i18n": "beta1",
-    "maquette": "2.4.3"
+    "@dojo/core": "next",
+    "@dojo/has": "next",
+    "@dojo/routing": "next",
+    "@dojo/shim": "next",
+    "@dojo/widget-core": "next",
+    "@dojo/i18n": "next"
   },
   "devDependencies": {
-    "@dojo/cli-build-webpack": "beta1",
-    "@dojo/cli-test-intern": "beta1",
-    "@dojo/interfaces": "beta1",
-    "@dojo/loader": "beta1",
+    "@dojo/cli-build-webpack": "next",
+    "@dojo/cli-test-intern": "next",
+    "@dojo/interfaces": "next",
+    "@dojo/loader": "next",
     "@types/chai": "~3.4.0",
     "@types/glob": "~5.0.0",
     "@types/grunt": "~0.4.0",
@@ -23,6 +22,6 @@
     "chai": "^3.5.0",
     "intern": "~3.4.1",
     "sinon": "^2.0.0",
-    "typescript": "~2.3.2"
+    "typescript": "~2.4.1"
   }
 }

--- a/src/templates/src/widgets/styles/HelloWorld.m.css
+++ b/src/templates/src/widgets/styles/HelloWorld.m.css
@@ -6,12 +6,12 @@
 	font-family: -apple-system, BlinkMacSystemFont;
 	margin: 1em;
 	padding: 1em;
-	position: fixed;
 	user-select: none;
+	width: 140px;
+	text-align: center;
 }
 
 .upsidedown {
 	transform: rotate(180deg);
 	color: red;
-	position: fixed;
 }

--- a/src/templates/tsconfig.json
+++ b/src/templates/tsconfig.json
@@ -1,11 +1,11 @@
 {
 	"compilerOptions": {
 		"declaration": false,
-		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"lib": [
 			"dom",
 			"es5",
+			"es2015.promise",
 			"es2015.iterable",
 			"es2015.symbol",
 			"es2015.symbol.wellknown"
@@ -22,7 +22,6 @@
 		"types": [ "intern" ]
 	},
 	"include": [
-		"./typings/index.d.ts",
 		"./src/**/*.ts",
 		"./tests/**/*.ts"
 	]


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

* Update the deps for the project template to use `next`
* Update TS to `~2.4.1`
* Add `es2015.promise` to tsconfig
* remove position fixed from styles
