### PR TITLE
Add `.gitignore.template` to the file list

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,7 @@ export function getDirectoryNames(appName: string): string[] {
 const fileNames = [
 	'package.json',
 	'tsconfig.json',
-	'.gitignore',
+	'.gitignore.template',
 	'README.md',
 	'src/index.html',
 	'src/main.ts',


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Resolves the error using when using `dojo create`:

```
UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): Error: ENOENT: no such file or directory, open '/node/v6.11.1/lib/node_modules/@dojo/cli/node_modules/@dojo/cli-create-app/templates/.gitignore'
```