### PR TITLE
Migrate to @dojo/interfaces/cli and @types

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "@dojo/cli": "next",
     "@dojo/loader": "next",
     "@types/chai": "^3.4.34",
     "@types/chalk": "^0.4.31",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@dojo/loader": "next",
+    "@dojo/interfaces": "next",
     "@types/chai": "^3.4.34",
     "@types/chalk": "^0.4.31",
     "@types/ejs": "^2.3.33",
@@ -36,6 +37,7 @@
     "@types/mockery": "^1.4.29",
     "@types/node": "^6.0.49",
     "@types/sinon": "^1.16.32",
+    "@types/yargs": "^8.0.2",
     "codecov.io": "0.1.6",
     "glob": "^7.0.3",
     "grunt": "~1.0.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Command } from '@dojo/cli/interfaces';
+import { Command } from '@dojo/interfaces/cli';
 import register from './register';
 import run from './run';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
 import { Command } from '@dojo/interfaces/cli';
 import register from './register';
-import run from './run';
+import run, { CreateAppArgs } from './run';
 
-const command: Command = {
+const command: Command<CreateAppArgs> = {
 	description: 'Scaffolds a new app',
 	register,
 	run

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,4 +1,4 @@
-import { OptionsHelper } from '@dojo/cli/interfaces';
+import { OptionsHelper } from '@dojo/interfaces/cli';
 
 export default function(options: OptionsHelper): void {
 	options('n', {

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { Helper } from '@dojo/cli/interfaces';
+import { Helper } from '@dojo/interfaces/cli';
 import createDir from './createDir';
 import renderFiles from './renderFiles';
 import npmInstall from './npmInstall';

--- a/src/run.ts
+++ b/src/run.ts
@@ -12,7 +12,7 @@ import dirname from './dirname';
 const pkgDir: any = require('pkg-dir');
 const packagePath = pkgDir.sync(dirname);
 
-export interface CreateAppArgs extends Argv {
+export interface CreateAppArgs {
 	name: string;
 }
 

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -1,6 +1,6 @@
 import { stub } from 'sinon';
 import * as yargs from 'yargs';
-import { Helper } from '@dojo/cli/interfaces';
+import { Helper } from '@dojo/interfaces/cli';
 
 export function getHelperStub(): Helper {
 	return {

--- a/tests/unit/run.ts
+++ b/tests/unit/run.ts
@@ -1,7 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { getHelperStub } from '../support/testHelper';
-import { Helper } from '@dojo/cli/interfaces';
+import { Helper } from '@dojo/interfaces/cli';
 import * as mockery from 'mockery';
 import { SinonStub, stub } from 'sinon';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
 		"types": [ "intern" ]
 	},
 	"include": [
-		"./typings/index.d.ts",
 		"./src/**/*.ts",
 		"./tests/**/*.ts"
 	],

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,0 @@
-{
-	"name": "dojo-cli-create-app",
-	"dependencies": {
-		"yargs": "registry:npm/yargs#5.0.0+20160817153026"
-	}
-}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Migrate to use `@dojo/interfaces/cli` and `@types` for other typings.

Depends on a release of `@dojo/interfaces`.

Refs: https://github.com/dojo/cli/issues/119