### PR TITLE
tslint failures for unused imports in template test

### DIFF
--- a/src/templates/tests/unit/widgets/HelloWorld.ts
+++ b/src/templates/tests/unit/widgets/HelloWorld.ts
@@ -1,8 +1,6 @@
 import * as registerSuite from 'intern/lib/interfaces/object';
-import { assert } from 'chai';
-import harness, { Harness } from '@dojo/test-extras/harness';
+import harness from '@dojo/test-extras/harness';
 
-import { WidgetProperties } from '@dojo/widget-core/interfaces';
 import { v } from '@dojo/widget-core/d';
 
 import HelloWorld from '../../../src/widgets/HelloWorld';


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Changing to test-extras, left unused imports in the unit test.
