### PR TITLE
Adding downleveliteration to cli-create-app template

### DIFF
--- a/src/templates/package.json
+++ b/src/templates/package.json
@@ -2,13 +2,13 @@
   "name": "<%- appName %>",
   "version": "1.0.0",
   "dependencies": {
-    "@dojo/core": "~0.1.0",
+    "@dojo/core": "~0.2.1",
     "@dojo/has": "~0.1.0",
     "@dojo/routing": "~0.1.0",
-    "@dojo/shim": "~0.1.0",
+    "@dojo/shim": "~0.2.2",
     "@dojo/widget-core": "~0.1.0",
     "@dojo/widgets": "~0.1.0",
-    "@dojo/i18n": "~0.1.0"
+    "@dojo/i18n": "~0.1.1"
   },
   "devDependencies": {
     "@dojo/cli-build-webpack": "~0.2.0",

--- a/src/templates/tsconfig.json
+++ b/src/templates/tsconfig.json
@@ -17,6 +17,8 @@
 		"noUnusedLocals": true,
 		"outDir": "_build/",
 		"removeComments": false,
+		"importHelpers": true,
+		"downlevelIteration": true,
 		"sourceMap": true,
 		"strict": true,
 		"target": "es5",


### PR DESCRIPTION
Upgrading shim/core versions and adding `importHelpers` and `downlevelIteration`.