### PR TITLE
Updating for future grunt-dojo2 updates

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,6 +8,18 @@ module.exports = function (grunt) {
 					'./src/templates',
 					"./tests/**/*.ts"
 				]
+			},
+			umd: {
+				exclude: [
+					'./src/templates',
+					"./tests/**/*.ts"
+				]
+			},
+			esm: {
+				exclude: [
+					'./src/templates',
+					"./tests/**/*.ts"
+				]
 			}
 		},
 		copy: {


### PR DESCRIPTION
Updates to work with future grunt-dojo2 changes.

When grunt-dojo2 is released we can get rid of the `dist` config.