### PR TITLE
Add Prettier with tslint plugin and precommit hook

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 The following has been addressed in the PR:
 
 * [ ] There is a related issue
-* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
+* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
 * [ ] Unit or Functional tests are included in the PR
 
 <!--

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The `create app` command for the `dojo cli`.
 - [Usage](#usage)
 - [Features](#features)
 - [How do I contribute?](#how-do-i-contribute)
+  - [Code Style](#code-style)
   - [Installation](#installation)
   - [Testing](#testing)
 - [Licensing information](#licensing-information)
@@ -45,7 +46,17 @@ When ready to create a production build run `dojo build`, the output will be ava
 ## How do I contribute?
 
 We appreciate your interest!  Please see the [Dojo 2 Meta Repository](https://github.com/dojo/meta#readme) for the
-Contributing Guidelines and Style Guide.
+Contributing Guidelines.
+
+### Code Style
+
+This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the projects `package.json`.
+
+An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
+
+```bash
+npm run prettier
+```
 
 ### Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7951,27 +7951,60 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.2.0.tgz",
-      "integrity": "sha1-FqKt3yDLdIOF9UTpoO2rCGvDQRQ=",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.8.0.tgz",
+      "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
-        "colors": "1.1.2",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
         "diff": "3.4.0",
-        "findup-sync": "0.3.0",
         "glob": "7.1.2",
-        "optimist": "0.6.1",
+        "minimatch": "3.0.4",
         "resolve": "1.5.0",
         "semver": "5.4.1",
         "tslib": "1.8.1",
-        "tsutils": "1.9.1"
+        "tsutils": "2.13.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        },
         "diff": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
           "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "resolve": {
@@ -7981,6 +8014,24 @@
           "dev": true,
           "requires": {
             "path-parse": "1.0.5"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "tsutils": {
+          "version": "2.13.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.13.1.tgz",
+          "integrity": "sha512-XMOEvc2TiYesVSOJMI7OYPnBMSgcvERuGW5Li/J+2A0TuH607BPQnOLQ82oSPZCssB8c9+QGi6qhTBa/f1xQRA==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.8.1"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/cli-create-app",
-  "version": "0.3.0",
+  "version": "0.3.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -22,7 +22,7 @@
       "integrity": "sha512-sgqHsKraTjKDoLfWece/E/ip29CsV3z+vEDSIzuBSWtXDEau6/pDRhbhuSnxjBB1bvvB8Drn93xWkO+PqqQ0Dg==",
       "dev": true,
       "requires": {
-        "@types/yargs": "8.0.2"
+        "@types/yargs": "8.0.3"
       }
     },
     "@dojo/loader": {
@@ -39,7 +39,7 @@
       "requires": {
         "intersection-observer": "0.4.3",
         "pepjs": "0.4.3",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@theintern/digdug": {
@@ -54,7 +54,7 @@
         "@dojo/shim": "0.2.3",
         "decompress": "4.2.0",
         "semver": "5.4.1",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@theintern/leadfoot": {
@@ -69,7 +69,7 @@
         "@dojo/shim": "0.2.3",
         "@types/jszip": "0.0.33",
         "jszip": "3.1.5",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@types/babel-types": {
@@ -91,13 +91,13 @@
       "dev": true,
       "requires": {
         "@types/express": "4.0.39",
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.94"
       }
     },
     "@types/chai": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.8.tgz",
-      "integrity": "sha512-m812CONwdZn/dMzkIJEY0yAs4apyTkTORgfB2UsMOxgkUbC205AHnm4T8I0I5gPg9MHrFc1dJ35iS75c0CJkjg==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.10.tgz",
+      "integrity": "sha512-Ejh1AXTY8lm+x91X/yar3G2z4x9RyKwdTVdyyu7Xj3dNB35fMNCnEWqTO9FgS3zjzlRNqk1MruYhgb8yhRN9rA==",
       "dev": true
     },
     "@types/chalk": {
@@ -112,7 +112,7 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.94"
       }
     },
     "@types/diff": {
@@ -122,9 +122,15 @@
       "dev": true
     },
     "@types/ejs": {
-      "version": "2.3.33",
-      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-2.3.33.tgz",
-      "integrity": "sha1-Ck4Keu7gmUQVSwbOWirGoRj5KwA=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-2.5.0.tgz",
+      "integrity": "sha512-mm6fwe7oF2ltOovvKf4ulneGAERJJOo4BFgp5cKDG194byeFOdTpB8Tsuqa9MGJeNydd/D5eh4vmYFOYylR8Rw==",
+      "dev": true
+    },
+    "@types/events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
       "dev": true
     },
     "@types/express": {
@@ -144,7 +150,7 @@
       "integrity": "sha512-QLAHjdLwEICm3thVbXSKRoisjfgMVI4xJH/HU8F385BR2HI7PmM6ax4ELXf8Du6sLmSpySXMYaI+xc//oQ/IFw==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.94"
       }
     },
     "@types/fs-extra": {
@@ -153,17 +159,18 @@
       "integrity": "sha1-Tv8v9bBqWjv8VErdOm7TTN+JIzU=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.94"
       }
     },
     "@types/glob": {
-      "version": "5.0.33",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
-      "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
+      "version": "5.0.34",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.34.tgz",
+      "integrity": "sha512-sUvpieq+HsWTLdkeOI8Mi8u22Ag3AoGuM3sv+XMP1bKtbaIAHpEA2f52K2mz6vK5PVhTa3bFyRZLZMqTxOo2Cw==",
       "dev": true,
       "requires": {
-        "@types/minimatch": "3.0.1",
-        "@types/node": "6.0.92"
+        "@types/events": "1.1.0",
+        "@types/minimatch": "3.0.2",
+        "@types/node": "6.0.94"
       }
     },
     "@types/grunt": {
@@ -172,7 +179,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.94"
       }
     },
     "@types/handlebars": {
@@ -252,9 +259,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.87",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.87.tgz",
-      "integrity": "sha512-AqRC+aEF4N0LuNHtcjKtvF9OTfqZI0iaBoe3dA6m/W+/YZJBZjBmW/QIZ8fBeXC6cnytSY9tBoFBqZ9uSCeVsw==",
+      "version": "4.14.91",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.91.tgz",
+      "integrity": "sha512-k+nc3moSlAaXacyvz4/c6D9lnUeI6AKsLvkXFuNzUEEqMw7sjDnLW2GqlJ4nyFgMX/p+QzvVG6zRoDo4lJIV5g==",
       "dev": true
     },
     "@types/marked": {
@@ -276,9 +283,9 @@
       "dev": true
     },
     "@types/minimatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz",
-      "integrity": "sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.2.tgz",
+      "integrity": "sha512-tctoxbfuMCxeI2CAsnwoZQfaBA+T7gPzDzDuiiFnyCSSyGYEB92cmRTh6E3tdR1hWsprbJ9IdbvX3PzLmJU/GA==",
       "dev": true
     },
     "@types/mockery": {
@@ -288,9 +295,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "6.0.92",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.92.tgz",
-      "integrity": "sha512-awEYSSTn7dauwVCYSx2CJaPTu0Z1Ht2oR1b2AD3CYao6ZRb+opb6EL43fzmD7eMFgMHzTBWSUzlWSD+S8xN0Nw==",
+      "version": "6.0.94",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.94.tgz",
+      "integrity": "sha512-CwopBfOTONzc1bDDTh8/KzW+zssiIPw+nSf27Y1cuGIkZJ7zuhkig6xO5p9pBW/RY99DznOMCIj+FXx8EIy+qw==",
       "dev": true
     },
     "@types/platform": {
@@ -305,7 +312,7 @@
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.94"
       }
     },
     "@types/serve-static": {
@@ -330,7 +337,7 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.94"
       }
     },
     "@types/sinon": {
@@ -357,13 +364,13 @@
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.94"
       }
     },
     "@types/yargs": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.2.tgz",
-      "integrity": "sha512-Upj9YsBZRgjEVPvsaeGru48d2JiyzBNZkmkebHyoaQ+UM9wqj/rp5mkilRjSq/Ga45yfd/zwrNuML9f2gGfVpw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.3.tgz",
+      "integrity": "sha512-YdxO7zGQf2qJeMgR0fNO8QTlj88L2zCP5GOddovoTyetgLiNDOUXcWzhWKb4EdZZlOjLQUA0JM8lW7VcKQL+9w==",
       "dev": true
     },
     "abbrev": {
@@ -443,6 +450,21 @@
         "string-width": "2.1.1"
       }
     },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -452,6 +474,18 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
+    "any-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
+      "integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
+      "dev": true
     },
     "any-promise": {
       "version": "1.3.0",
@@ -468,6 +502,12 @@
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
       }
+    },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+      "dev": true
     },
     "append-transform": {
       "version": "0.4.0",
@@ -602,7 +642,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000783",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -666,14 +706,14 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
           "dev": true
         }
       }
@@ -952,7 +992,7 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000783",
         "electron-to-chromium": "1.3.28"
       }
     },
@@ -1016,15 +1056,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000783",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000778",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000778.tgz",
-      "integrity": "sha1-Fnxg6VQqKqYFN8RG+ziB2FOjByo=",
+      "version": "1.0.30000783",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000783.tgz",
+      "integrity": "sha1-FrMNRyZqT1FcxprgMWtnDJYDzb4=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1108,6 +1148,12 @@
         "readdirp": "1.4.0"
       }
     },
+    "ci-info": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "dev": true
+    },
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
@@ -1135,6 +1181,38 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.2.0.tgz",
       "integrity": "sha1-hQeHN5E7iA9uyf/ntl6D7Hd2KE8="
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
+      }
     },
     "cliui": {
       "version": "2.1.0",
@@ -1234,6 +1312,12 @@
       "requires": {
         "color-name": "1.1.3"
       }
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
     },
     "colormin": {
       "version": "1.1.2",
@@ -1371,6 +1455,45 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cosmiconfig": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+      "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+      "dev": true,
+      "requires": {
+        "is-directory": "0.3.1",
+        "js-yaml": "3.10.0",
+        "parse-json": "3.0.0",
+        "require-from-string": "2.0.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+          "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        }
+      }
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -1604,6 +1727,12 @@
         "array-find-index": "1.0.2"
       }
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
     "dateformat": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
@@ -1707,6 +1836,12 @@
           "dev": true
         }
       }
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -1871,6 +2006,12 @@
       "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
       "dev": true
     },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
+    },
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
@@ -1941,6 +2082,16 @@
             "amdefine": "1.0.1"
           }
         }
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz",
+      "integrity": "sha512-P0EohHM1MwL36GX5l1TOEYyt/5d7hcxrX3CqCjibTN3dH7VCAy2kjsC/WB6dUHnpB4mFkZq1Ndfh2DYQ2QMEGQ==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
       }
     },
     "esprima": {
@@ -2106,14 +2257,21 @@
       }
     },
     "fancy-log": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
         "time-stamp": "1.1.0"
       }
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2143,6 +2301,16 @@
       "dev": true,
       "requires": {
         "pend": "1.2.0"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "file-sync-cmp": {
@@ -2213,6 +2381,12 @@
           "dev": true
         }
       }
+    },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
     },
     "find-up": {
       "version": "1.1.2",
@@ -2374,6 +2548,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
       "dev": true
     },
     "get-stdin": {
@@ -2678,7 +2858,7 @@
         "grunt-ts": "5.5.1",
         "grunt-tslint": "4.0.1",
         "grunt-typings": "0.1.5",
-        "intern": "4.1.3",
+        "intern": "4.1.4",
         "istanbul-lib-coverage": "1.1.1",
         "istanbul-lib-report": "1.1.2",
         "istanbul-reports": "1.1.3",
@@ -2697,11 +2877,40 @@
         "umd-wrapper": "0.1.0"
       },
       "dependencies": {
+        "diff": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "dev": true
+        },
+        "grunt-tslint": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
+          "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+          "dev": true
+        },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
+        },
+        "tslint": {
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
+          "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "colors": "1.1.2",
+            "diff": "3.4.0",
+            "findup-sync": "0.3.0",
+            "glob": "7.1.2",
+            "optimist": "0.6.1",
+            "resolve": "1.1.7",
+            "tsutils": "1.9.1",
+            "update-notifier": "2.3.0"
+          }
         }
       }
     },
@@ -2843,9 +3052,9 @@
       }
     },
     "grunt-tslint": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
-      "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-5.0.1.tgz",
+      "integrity": "sha1-dDK9G9VuijolAACI1cYf3MNC8MI=",
       "dev": true
     },
     "grunt-typings": {
@@ -2868,7 +3077,7 @@
         "beeper": "1.1.1",
         "chalk": "1.1.3",
         "dateformat": "1.0.12",
-        "fancy-log": "1.3.0",
+        "fancy-log": "1.3.2",
         "gulplog": "1.0.0",
         "has-gulplog": "0.1.0",
         "lodash._reescape": "3.0.0",
@@ -3090,6 +3299,31 @@
         "extend": "3.0.1"
       }
     },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.0.10",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -3162,9 +3396,9 @@
       "dev": true
     },
     "intern": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.3.tgz",
-      "integrity": "sha512-IWaqzIwc+KQcoyiG+INvvv9L0fPKmgDSj+LySSWgnPc0VnYT1vgEmmxpwSlMPHDtfMMqq28/5/tsQVRx4EM2bQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.4.tgz",
+      "integrity": "sha512-QL5+pVjpjNVtp5mB2QwTgf3fuG3l+lA3UzhHTxjhahWt0Z84LfdFfHFXN6UeB72IYQq7LDhjStO6I51rsTjb6Q==",
       "dev": true,
       "requires": {
         "@dojo/core": "0.3.0",
@@ -3174,7 +3408,7 @@
         "@theintern/digdug": "2.0.4",
         "@theintern/leadfoot": "2.0.3",
         "@types/benchmark": "1.0.31",
-        "@types/chai": "4.0.8",
+        "@types/chai": "4.0.10",
         "@types/charm": "1.0.1",
         "@types/diff": "3.2.2",
         "@types/express": "4.0.39",
@@ -3185,7 +3419,7 @@
         "@types/istanbul-lib-report": "1.1.0",
         "@types/istanbul-lib-source-maps": "1.2.0",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.87",
+        "@types/lodash": "4.14.91",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -3215,7 +3449,7 @@
         "shell-quote": "1.6.1",
         "source-map": "0.5.7",
         "statuses": "1.3.1",
-        "tslib": "1.8.0",
+        "tslib": "1.8.1",
         "ws": "2.3.1"
       },
       "dependencies": {
@@ -3410,6 +3644,21 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.2"
+      }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -3495,6 +3744,15 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+      "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "0.2.4"
+      }
+    },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
@@ -3522,10 +3780,22 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
     "is-relative": {
@@ -3775,6 +4045,67 @@
         "handlebars": "4.0.11"
       }
     },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
+    },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true
+    },
+    "jest-validate": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "jest-get-type": "21.2.0",
+        "leven": "2.1.0",
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "js-base64": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
@@ -3912,6 +4243,12 @@
         "invert-kv": "1.0.0"
       }
     },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -3931,11 +4268,267 @@
         "immediate": "3.0.6"
       }
     },
+    "lint-staged": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-6.0.0.tgz",
+      "integrity": "sha512-ZUftK94S4vedpQG1LlA2tc2AuQXXBwc+1lB+j8SEfG5+p2dqu3Ug8iYQ8jdap+uLkhDw4OaJXqE+CZ/L+vfv+Q==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
+        "dedent": "0.7.0",
+        "execa": "0.8.0",
+        "find-parent-dir": "0.3.0",
+        "is-glob": "4.0.0",
+        "jest-validate": "21.2.1",
+        "listr": "0.13.0",
+        "lodash": "4.17.4",
+        "log-symbols": "2.1.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "path-is-inside": "1.0.2",
+        "pify": "3.0.0",
+        "staged-git-files": "0.0.4",
+        "stringify-object": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
+          "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "listify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/listify/-/listify-1.0.0.tgz",
       "integrity": "sha1-A8p7otFQ1CZ3c/dOV1WNEFPSvuM=",
       "dev": true
+    },
+    "listr": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
+      "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-observable": "0.2.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.5",
+        "stream-to-observable": "0.2.0",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "cli-spinners": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+          "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+          "dev": true
+        },
+        "ora": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+          "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-spinners": "0.1.2",
+            "object-assign": "4.1.1"
+          }
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
+      }
     },
     "livereload-js": {
       "version": "2.2.2",
@@ -4133,6 +4726,16 @@
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "requires": {
         "chalk": "1.1.3"
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
       }
     },
     "lolex": {
@@ -4464,6 +5067,15 @@
         "sort-keys": "1.1.2"
       }
     },
+    "npm-path": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
+      "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
+      "dev": true,
+      "requires": {
+        "which": "1.3.0"
+      }
+    },
     "npm-run-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
@@ -4471,6 +5083,25 @@
       "dev": true,
       "requires": {
         "path-key": "1.0.0"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "2.12.2",
+        "npm-path": "2.0.3",
+        "which": "1.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        }
       }
     },
     "num2fraction": {
@@ -4706,6 +5337,12 @@
       "requires": {
         "p-limit": "1.1.0"
       }
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
     },
     "package-json": {
       "version": "4.0.1",
@@ -6015,6 +6652,39 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
+      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
+      }
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -6313,9 +6983,9 @@
       "dev": true
     },
     "regenerator-runtime": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "regex-cache": {
@@ -6456,6 +7126,12 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -6520,6 +7196,23 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "7.1.2"
+      }
+    },
+    "rxjs": {
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.5.tgz",
+      "integrity": "sha512-D/MfQnPMBk8P8gfwGxvCkuaWBcG58W7dUMT//URPoYzIbDEKT0GezdirkK5whMgKFBATfCoTpxO8bJQGJ04W5A==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {
@@ -6718,6 +7411,12 @@
         "util": "0.10.3"
       }
     },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
@@ -6791,6 +7490,12 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "staged-git-files": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
+      "dev": true
+    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -6804,6 +7509,15 @@
       "dev": true,
       "requires": {
         "duplexer": "0.1.1"
+      }
+    },
+    "stream-to-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
+      "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
+      "dev": true,
+      "requires": {
+        "any-observable": "0.2.0"
       }
     },
     "strict-uri-encode": {
@@ -6856,6 +7570,17 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
+    },
+    "stringify-object": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz",
+      "integrity": "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -6942,6 +7667,12 @@
           }
         }
       }
+    },
+    "symbol-observable": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+      "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+      "dev": true
     },
     "tape": {
       "version": "2.3.0",
@@ -7214,15 +7945,15 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-      "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=",
       "dev": true
     },
     "tslint": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
-      "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.2.0.tgz",
+      "integrity": "sha1-FqKt3yDLdIOF9UTpoO2rCGvDQRQ=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
@@ -7231,9 +7962,10 @@
         "findup-sync": "0.3.0",
         "glob": "7.1.2",
         "optimist": "0.6.1",
-        "resolve": "1.1.7",
-        "tsutils": "1.9.1",
-        "update-notifier": "2.3.0"
+        "resolve": "1.5.0",
+        "semver": "5.4.1",
+        "tslib": "1.8.1",
+        "tsutils": "1.9.1"
       },
       "dependencies": {
         "diff": {
@@ -7241,7 +7973,26 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
           "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
           "dev": true
+        },
+        "resolve": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          }
         }
+      }
+    },
+    "tslint-plugin-prettier": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz",
+      "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-prettier": "2.4.0",
+        "tslib": "1.8.1"
       }
     },
     "tsutils": {
@@ -8464,7 +9215,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.87",
+        "@types/lodash": "4.14.91",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",
@@ -8486,7 +9237,7 @@
           "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
           "dev": true,
           "requires": {
-            "@types/node": "6.0.92"
+            "@types/node": "6.0.94"
           }
         },
         "@types/minimatch": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "remap-istanbul": ">=0.6.3",
     "sinon": "^1.17.5",
     "tslib": "~1.8.0",
-    "tslint": "5.2.0",
+    "tslint": "5.8.0",
     "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1",
     "yargs": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "url": "https://github.com/dojo/cli-create-app.git"
   },
   "scripts": {
+    "prepublish": "grunt peerDepInstall",
+    "precommit": "lint-staged",
+    "prettier": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
     "test": "grunt test"
   },
   "devDependencies": {
@@ -42,18 +45,22 @@
     "grunt": "~1.0.1",
     "grunt-contrib-clean": ">=1.0.0",
     "grunt-contrib-copy": ">=1.0.0",
+    "grunt-dojo2": "latest",
     "grunt-postcss": "^0.8.0",
     "grunt-text-replace": ">=0.4.0",
     "grunt-ts": ">=5.0.0",
-    "grunt-tslint": "^4.0.1",
+    "grunt-tslint": "5.0.1",
     "grunt-typings": "^0.1.5",
-    "grunt-dojo2": "latest",
+    "husky": "0.14.3",
     "intern": "~4.1.0",
+    "lint-staged": "6.0.0",
     "mockery": "^1.7.0",
+    "prettier": "1.9.2",
     "remap-istanbul": ">=0.6.3",
     "sinon": "^1.17.5",
     "tslib": "~1.8.0",
-    "tslint": "^4.5.1",
+    "tslint": "5.2.0",
+    "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1",
     "yargs": "^5.0.0"
   },
@@ -64,5 +71,19 @@
     "fs-extra": "^0.30.0",
     "ora": "^0.3.0",
     "pkg-dir": "^1.0.0"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "tabWidth": 4,
+    "useTabs": true,
+    "parser": "typescript",
+    "printWidth": 120,
+    "arrowParens": "always"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { format, join, normalize, parse  } from 'path';
+import { format, join, normalize, parse } from 'path';
 
 export function getDirectoryNames(appName: string): string[] {
 	return [
@@ -40,7 +40,7 @@ export function stripTemplateFromFileName(filePath: string) {
 	return normalize(format(path));
 }
 
-export function getRenderFilesConfig(packagePath: string): {src: string, dest: string}[] {
+export function getRenderFilesConfig(packagePath: string): { src: string; dest: string }[] {
 	return fileNames.map((fileName) => {
 		const fileNameParts = fileName.split('/');
 		return {

--- a/src/createDir.ts
+++ b/src/createDir.ts
@@ -1,9 +1,9 @@
 import { mkdirsSync } from 'fs-extra';
 import * as chalk from 'chalk';
 
-export default function (...dirPath: string[]) {
+export default function(...dirPath: string[]) {
 	dirPath.forEach((path) => {
 		console.info(chalk.green.bold(' create ') + path);
 		mkdirsSync(path);
 	});
-};
+}

--- a/src/npmInstall.ts
+++ b/src/npmInstall.ts
@@ -2,15 +2,16 @@ import { red, green } from 'chalk';
 const cs: any = require('cross-spawn');
 const ora: any = require('ora');
 
-export default async function () {
+export default async function() {
 	return new Promise((resolve, reject) => {
 		const spinner = ora({
 			spinner: 'dots',
 			color: 'white',
 			text: 'npm install'
 		}).start();
-		cs.spawn('npm', ['install'], { stdio: 'ignore' })
-			.on('exit', function(code: Number){
+		cs
+			.spawn('npm', ['install'], { stdio: 'ignore' })
+			.on('exit', function(code: Number) {
 				if (code !== 0) {
 					spinner.stopAndPersist(red.bold(' failed'));
 					reject(new Error(`exit code: ${code}`));

--- a/src/renderFiles.ts
+++ b/src/renderFiles.ts
@@ -5,8 +5,8 @@ export type RenderFilesConfig = {
 	dest: string;
 }[];
 
-export default function (renderFilesConfig: RenderFilesConfig, renderData: any) {
+export default function(renderFilesConfig: RenderFilesConfig, renderData: any) {
 	renderFilesConfig.forEach(({ src, dest }) => {
 		template(src, dest, renderData);
 	});
-};
+}

--- a/src/template.ts
+++ b/src/template.ts
@@ -24,8 +24,8 @@ export function writeRenderedFile(str: string, destination: string): Promise<voi
 	});
 }
 
-export default async function (source: string, destination: string, replacements: Object): Promise<void> {
+export default async function(source: string, destination: string, replacements: Object): Promise<void> {
 	console.info(chalk.green.bold(' create ') + destination);
 	const str = await ejsRender(source, replacements);
 	await writeRenderedFile(str, destination);
-};
+}

--- a/src/templates/src/widgets/HelloWorld.ts
+++ b/src/templates/src/widgets/HelloWorld.ts
@@ -19,7 +19,7 @@ export class HelloWorld extends WidgetBase {
 		// Use WidgetBase#classes() to assign CSS classnames from the theme to the virtual DOM nodes.
 		return v('div', { classes: css.root }, [
 			v('img', { src: './img/logo.svg', classes: css.logo }),
-			v('div', { classes: css.label }, [ 'Hello, Dojo 2 World!' ])
+			v('div', { classes: css.label }, ['Hello, Dojo 2 World!'])
 		]);
 	}
 }

--- a/src/templates/tests/unit/widgets/HelloWorld.ts
+++ b/src/templates/tests/unit/widgets/HelloWorld.ts
@@ -9,9 +9,11 @@ import * as css from '../../../src/widgets/styles/HelloWorld.m.css';
 describe('HelloWorld', () => {
 	it('should render widget', () => {
 		const testHelloWorld = harness(HelloWorld);
-		testHelloWorld.expectRender(v('div', { classes: css.root }, [
-			v('img', { src: './img/logo.svg', classes: css.logo }),
-			v('div', { classes: css.label }, [ 'Hello, Dojo 2 World!' ])
-		]));
+		testHelloWorld.expectRender(
+			v('div', { classes: css.root }, [
+				v('img', { src: './img/logo.svg', classes: css.logo }),
+				v('div', { classes: css.label }, ['Hello, Dojo 2 World!'])
+			])
+		);
 	});
 });

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -16,7 +16,7 @@ export const capabilities = {
 };
 
 // Support running unit tests from a web server that isn't the intern proxy
-export const initialBaseUrl: string | null = (function () {
+export const initialBaseUrl: string | null = (function() {
 	if (typeof location !== 'undefined' && location.pathname.indexOf('__intern/') > -1) {
 		return '/';
 	}
@@ -35,13 +35,13 @@ export const loaderOptions = {
 	// Packages that should be registered with the loader in each testing environment
 	packages: [
 		{ name: 'src', location: '_build/src' },
-		{ name: 'grunt-dojo2', location: 'node_modules/grunt-dojo2'},
+		{ name: 'grunt-dojo2', location: 'node_modules/grunt-dojo2' },
 		{ name: 'tests', location: '_build/tests' }
 	]
 };
 
 // Non-functional test suite(s) to run in each browser
-export const suites = [ 'tests/unit/all' ];
+export const suites = ['tests/unit/all'];
 
 // A regular expression matching URLs to files that should not be included in code coverage analysis
 export const excludeInstrumentation = /(?:node_modules|bower_components|tests|templates)[\/\\]|dirname/;

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -15,7 +15,7 @@ export function getHelperStub(): Helper {
 			get: stub().returns(Promise.resolve())
 		}
 	};
-};
+}
 
 const yargsFunctions = ['demand', 'usage', 'epilog', 'help', 'alias'];
 export function getYargsStub() {

--- a/tests/support/util.ts
+++ b/tests/support/util.ts
@@ -6,11 +6,14 @@ export interface Thenable<T> {
 }
 
 export function isEventuallyRejected<T>(promise: Thenable<T>): Thenable<boolean> {
-	return promise.then<any>(function () {
-		throw new Error('unexpected code path');
-	}, function () {
-		return true; // expect rejection
-	});
+	return promise.then<any>(
+		function() {
+			throw new Error('unexpected code path');
+		},
+		function() {
+			return true; // expect rejection
+		}
+	);
 }
 
 export function throwImmediatly() {

--- a/tests/unit/changeDir.ts
+++ b/tests/unit/changeDir.ts
@@ -14,11 +14,11 @@ registerSuite('changeDir', {
 	},
 
 	tests: {
-	'Should call process chdir with given path'() {
-		const path = 'testPath';
-		changeDir(path);
-		assert.isTrue(changeDirStub.calledOnce);
-		assert.isTrue(changeDirStub.firstCall.calledWith(path));
-	}
+		'Should call process chdir with given path'() {
+			const path = 'testPath';
+			changeDir(path);
+			assert.isTrue(changeDirStub.calledOnce);
+			assert.isTrue(changeDirStub.firstCall.calledWith(path));
+		}
 	}
 });

--- a/tests/unit/config.ts
+++ b/tests/unit/config.ts
@@ -17,25 +17,32 @@ registerSuite('config', {
 	},
 
 	tests: {
-	'Should return directory names to create inside the specified app name'() {
-		const folderNames = getDirectoryNames(appName);
-		assert.equal(10, folderNames.length, 'length');
-		folderNames.forEach((folderName: string) => {
-			assert.isTrue(folderName.indexOf(appName) === 0, 'folder name should be within app folder');
-		});
-	},
-	'Should strip "template-" from fileName'() {
-		assert.equal(stripTemplateFromFileName('/foo/bar/template-.gitignore'), `${path.sep}foo${path.sep}bar${path.sep}.gitignore`);
-	},
-	'Should return config of file names using the given package path'() {
-		const renderFilesConfig = getRenderFilesConfig(packagePath);
+		'Should return directory names to create inside the specified app name'() {
+			const folderNames = getDirectoryNames(appName);
+			assert.equal(10, folderNames.length, 'length');
+			folderNames.forEach((folderName: string) => {
+				assert.isTrue(folderName.indexOf(appName) === 0, 'folder name should be within app folder');
+			});
+		},
+		'Should strip "template-" from fileName'() {
+			assert.equal(
+				stripTemplateFromFileName('/foo/bar/template-.gitignore'),
+				`${path.sep}foo${path.sep}bar${path.sep}.gitignore`
+			);
+		},
+		'Should return config of file names using the given package path'() {
+			const renderFilesConfig = getRenderFilesConfig(packagePath);
 
-		renderFilesConfig.forEach(({ src }) => {
-			assert.isTrue(src.indexOf(packagePath) === 0, 'src should be within package path');
-			assert.isTrue(src.indexOf('templates') > -1, 'src should be within templates folder');
-		});
+			renderFilesConfig.forEach(({ src }) => {
+				assert.isTrue(src.indexOf(packagePath) === 0, 'src should be within package path');
+				assert.isTrue(src.indexOf('templates') > -1, 'src should be within templates folder');
+			});
 
-		assert.equal(renderFilesConfig.length * 2, joinSpy.callCount, 'join should be called twice for each file config');
-	}
+			assert.equal(
+				renderFilesConfig.length * 2,
+				joinSpy.callCount,
+				'join should be called twice for each file config'
+			);
+		}
 	}
 });

--- a/tests/unit/createDir.ts
+++ b/tests/unit/createDir.ts
@@ -22,19 +22,19 @@ registerSuite('createDir', {
 	},
 
 	tests: {
-	'Should call mkdir when passed a path'() {
-		const folderName = 'tmp/folder';
-		createDir(folderName);
-		assert.isTrue(mkdirsStub.calledOnce);
-		assert.isTrue(mkdirsStub.firstCall.calledWith(folderName));
-	},
-	'Should call mkdir multiple times when passed multiple paths'() {
-		const folderName1 = 'tmp/folder';
-		const folderName2 = 'tmp/folder2';
-		createDir(folderName1, folderName2);
-		assert.isTrue(mkdirsStub.calledTwice);
-		assert.isTrue(mkdirsStub.firstCall.calledWith(folderName1));
-		assert.isTrue(mkdirsStub.secondCall.calledWith(folderName2));
-	}
+		'Should call mkdir when passed a path'() {
+			const folderName = 'tmp/folder';
+			createDir(folderName);
+			assert.isTrue(mkdirsStub.calledOnce);
+			assert.isTrue(mkdirsStub.firstCall.calledWith(folderName));
+		},
+		'Should call mkdir multiple times when passed multiple paths'() {
+			const folderName1 = 'tmp/folder';
+			const folderName2 = 'tmp/folder2';
+			createDir(folderName1, folderName2);
+			assert.isTrue(mkdirsStub.calledTwice);
+			assert.isTrue(mkdirsStub.firstCall.calledWith(folderName1));
+			assert.isTrue(mkdirsStub.secondCall.calledWith(folderName2));
+		}
 	}
 });

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -13,11 +13,11 @@ registerSuite('main', {
 		});
 
 		mockery.registerMock('./run', {
-			'default': runStub
+			default: runStub
 		});
 
 		mockery.registerMock('./register', {
-			'default': registerStub
+			default: registerStub
 		});
 
 		main = require('../../src/main');
@@ -28,11 +28,11 @@ registerSuite('main', {
 	},
 
 	tests: {
-	'Should return a command matching the interface'() {
-		const command = main.default;
-		assert.isTrue(typeof command.description === 'string');
-		assert.equal(runStub, command.run);
-		assert.equal(registerStub, command.register);
-	}
+		'Should return a command matching the interface'() {
+			const command = main.default;
+			assert.isTrue(typeof command.description === 'string');
+			assert.equal(runStub, command.run);
+			assert.equal(registerStub, command.register);
+		}
 	}
 });

--- a/tests/unit/npmInstall.ts
+++ b/tests/unit/npmInstall.ts
@@ -32,7 +32,7 @@ registerSuite('npmInstall', {
 	beforeEach() {
 		spawnOnStub = stub();
 		const spawnOnResponse = {
-			'on': spawnOnStub
+			on: spawnOnStub
 		};
 
 		startStub.reset();
@@ -45,46 +45,50 @@ registerSuite('npmInstall', {
 	},
 
 	tests: {
-	async 'Should call spawn to run an npm process'() {
-		spawnOnStub.onFirstCall().callsArgWith(1, 0);
-		await npmInstall.default();
-		assert.isTrue(spawnStub.calledOnce);
-	},
-	async 'Should use a loading spinner'() {
-		spawnOnStub.onFirstCall().callsArgWith(1, 0);
-		await npmInstall.default();
-		assert.isTrue(startStub.calledOnce, 'Should call start on the spinner');
-		assert.isTrue(stopAndPersistStub.calledOnce, 'Should stop the spinner');
-		assert.isTrue(stopAndPersistStub.firstCall.calledWithMatch('completed'),
-			'Should persist completed message');
-	},
-	async 'Should reject with an error when spawn throws an error'() {
-		const errorMessage = 'test error message';
-		spawnOnStub.onSecondCall().callsArgWith(1, new Error(errorMessage));
-		try {
+		async 'Should call spawn to run an npm process'() {
+			spawnOnStub.onFirstCall().callsArgWith(1, 0);
 			await npmInstall.default();
-			assert.fail(null, null, 'Should not get here');
-		}
-		catch (error) {
-			assert.equal(error.message, errorMessage);
-			assert.isTrue(stopAndPersistStub.calledOnce, 'Should stop the spinner');
-			assert.isTrue(stopAndPersistStub.firstCall.calledWithMatch('failed'),
-				'Should persis the failed message');
-		}
-	},
-	async 'Should reject with an error when spawn process returns an exit code !== 0'() {
-		const errorExitCode = 1;
-		spawnOnStub.onFirstCall().callsArgWith(1, errorExitCode);
-		try {
+			assert.isTrue(spawnStub.calledOnce);
+		},
+		async 'Should use a loading spinner'() {
+			spawnOnStub.onFirstCall().callsArgWith(1, 0);
 			await npmInstall.default();
-			assert.fail(null, null, 'Should not get here');
-		}
-		catch (error) {
-			assert.equal(error.message, `exit code: ${errorExitCode}` );
+			assert.isTrue(startStub.calledOnce, 'Should call start on the spinner');
 			assert.isTrue(stopAndPersistStub.calledOnce, 'Should stop the spinner');
-			assert.isTrue(stopAndPersistStub.firstCall.calledWithMatch('failed'),
-				'Should persis the failed message');
+			assert.isTrue(
+				stopAndPersistStub.firstCall.calledWithMatch('completed'),
+				'Should persist completed message'
+			);
+		},
+		async 'Should reject with an error when spawn throws an error'() {
+			const errorMessage = 'test error message';
+			spawnOnStub.onSecondCall().callsArgWith(1, new Error(errorMessage));
+			try {
+				await npmInstall.default();
+				assert.fail(null, null, 'Should not get here');
+			} catch (error) {
+				assert.equal(error.message, errorMessage);
+				assert.isTrue(stopAndPersistStub.calledOnce, 'Should stop the spinner');
+				assert.isTrue(
+					stopAndPersistStub.firstCall.calledWithMatch('failed'),
+					'Should persis the failed message'
+				);
+			}
+		},
+		async 'Should reject with an error when spawn process returns an exit code !== 0'() {
+			const errorExitCode = 1;
+			spawnOnStub.onFirstCall().callsArgWith(1, errorExitCode);
+			try {
+				await npmInstall.default();
+				assert.fail(null, null, 'Should not get here');
+			} catch (error) {
+				assert.equal(error.message, `exit code: ${errorExitCode}`);
+				assert.isTrue(stopAndPersistStub.calledOnce, 'Should stop the spinner');
+				assert.isTrue(
+					stopAndPersistStub.firstCall.calledWithMatch('failed'),
+					'Should persis the failed message'
+				);
+			}
 		}
-	}
 	}
 });

--- a/tests/unit/register.ts
+++ b/tests/unit/register.ts
@@ -14,21 +14,21 @@ registerSuite('register', {
 	},
 
 	tests: {
-	'Should add a yargs option for name'() {
-		const options = sandbox.stub();
-		register(options);
-		assert.isTrue(options.calledOnce);
-		assert.isTrue(options.firstCall.calledWithMatch('n', { 'alias': 'name' }));
-	},
-	'Should demand the name option'() {
-		const options = sandbox.stub();
-		register(options);
-		assert.isTrue(options.firstCall.calledWithMatch('n', { 'demand': true }));
-	},
-	'Should require a value for the name option'() {
-		const options = sandbox.stub();
-		register(options);
-		assert.isTrue(options.firstCall.calledWithMatch('n', { 'requiresArg': true }));
-	}
+		'Should add a yargs option for name'() {
+			const options = sandbox.stub();
+			register(options);
+			assert.isTrue(options.calledOnce);
+			assert.isTrue(options.firstCall.calledWithMatch('n', { alias: 'name' }));
+		},
+		'Should demand the name option'() {
+			const options = sandbox.stub();
+			register(options);
+			assert.isTrue(options.firstCall.calledWithMatch('n', { demand: true }));
+		},
+		'Should require a value for the name option'() {
+			const options = sandbox.stub();
+			register(options);
+			assert.isTrue(options.firstCall.calledWithMatch('n', { requiresArg: true }));
+		}
 	}
 });

--- a/tests/unit/renderFiles.ts
+++ b/tests/unit/renderFiles.ts
@@ -5,12 +5,9 @@ import * as mockery from 'mockery';
 
 const templateStub: SinonStub = stub();
 const testRenderData = {
-	'appName': 'testName'
+	appName: 'testName'
 };
-const testFilesConfig = [
-	{ src: 'test/a', dest: 'dest/a' },
-	{ src: 'test/b', dest: 'dest/b' }
-];
+const testFilesConfig = [{ src: 'test/a', dest: 'dest/a' }, { src: 'test/b', dest: 'dest/b' }];
 
 let renderFiles: any;
 
@@ -21,7 +18,7 @@ registerSuite('renderFiles', {
 		});
 
 		mockery.registerMock('./template', {
-			'default': templateStub
+			default: templateStub
 		});
 
 		renderFiles = require('../../src/renderFiles');
@@ -35,15 +32,15 @@ registerSuite('renderFiles', {
 	},
 
 	tests: {
-	async 'Should call template for each file in the config'() {
-		await renderFiles.default(testFilesConfig, testRenderData);
-		assert.equal(2, templateStub.callCount);
-	},
-	async 'Should call template with the src and dest from config'() {
-		await renderFiles.default(testFilesConfig, testRenderData);
-		const [ file1, file2 ] = testFilesConfig;
-		assert.isTrue(templateStub.firstCall.calledWithMatch(file1.src, file1.dest));
-		assert.isTrue(templateStub.secondCall.calledWithMatch(file2.src, file2.dest));
-	}
+		async 'Should call template for each file in the config'() {
+			await renderFiles.default(testFilesConfig, testRenderData);
+			assert.equal(2, templateStub.callCount);
+		},
+		async 'Should call template with the src and dest from config'() {
+			await renderFiles.default(testFilesConfig, testRenderData);
+			const [file1, file2] = testFilesConfig;
+			assert.isTrue(templateStub.firstCall.calledWithMatch(file1.src, file1.dest));
+			assert.isTrue(templateStub.secondCall.calledWithMatch(file2.src, file2.dest));
+		}
 	}
 });

--- a/tests/unit/run.ts
+++ b/tests/unit/run.ts
@@ -6,12 +6,12 @@ import * as mockery from 'mockery';
 import { SinonStub, stub } from 'sinon';
 
 type ESModule = {
-	default: any
+	default: any;
 };
 
 const name = 'testAppName';
 const args = { name };
-const dirNames = [ name, name + '/tests' ];
+const dirNames = [name, name + '/tests'];
 const existsSyncStub: SinonStub = stub();
 const createDirStub: SinonStub = stub();
 const renderFilesStub: SinonStub = stub().returns(Promise.resolve());
@@ -29,20 +29,20 @@ registerSuite('run', {
 	before() {
 		consoleStub = stub(console, 'info');
 
-		mockery.enable({ 'warnOnUnregistered': false });
+		mockery.enable({ warnOnUnregistered: false });
 
-		mockery.registerMock('fs-extra', { 'existsSync': existsSyncStub });
-		mockery.registerMock('./createDir', { 'default': createDirStub });
-		mockery.registerMock('./renderFiles', { 'default': renderFilesStub });
-		mockery.registerMock('./npmInstall', { 'default': npmInstallStub });
-		mockery.registerMock('./changeDir', { 'default': changeDirStub });
+		mockery.registerMock('fs-extra', { existsSync: existsSyncStub });
+		mockery.registerMock('./createDir', { default: createDirStub });
+		mockery.registerMock('./renderFiles', { default: renderFilesStub });
+		mockery.registerMock('./npmInstall', { default: npmInstallStub });
+		mockery.registerMock('./changeDir', { default: changeDirStub });
 		mockery.registerMock('./config', {
-			'getDirectoryNames': getDirectoryNamesStub,
-			'getRenderFilesConfig': getRenderFilesConfigStub
+			getDirectoryNames: getDirectoryNamesStub,
+			getRenderFilesConfig: getRenderFilesConfigStub
 		});
-		mockery.registerMock('pkg-dir', { 'sync': pkgDirStub });
+		mockery.registerMock('pkg-dir', { sync: pkgDirStub });
 
-		run = (<ESModule> require('../../src/run')).default;
+		run = (<ESModule>require('../../src/run')).default;
 	},
 	after() {
 		consoleStub.restore();
@@ -64,46 +64,45 @@ registerSuite('run', {
 	},
 
 	tests: {
-	async 'Should check to see if target appName folder exists'() {
-		existsSyncStub.returns(true);
-		try {
+		async 'Should check to see if target appName folder exists'() {
+			existsSyncStub.returns(true);
+			try {
+				await run(helperStub, args);
+				assert.fail(null, null, 'Should not get here');
+			} catch (error) {
+				assert.equal('App directory already exists', error.message);
+				assert.isTrue(existsSyncStub.calledOnce);
+				assert.isTrue(existsSyncStub.firstCall.calledWith(name));
+			}
+		},
+		async 'Should get directories to create from config'() {
 			await run(helperStub, args);
-			assert.fail(null, null, 'Should not get here');
+			assert.isTrue(getDirectoryNamesStub.calledOnce);
+			assert.isTrue(createDirStub.calledOnce);
+			assert.isTrue(createDirStub.firstCall.calledWith(...dirNames));
+			assert.isTrue(createDirStub.calledAfter(existsSyncStub));
+		},
+		async 'Should change to the appname directory'() {
+			await run(helperStub, args);
+			assert.isTrue(changeDirStub.calledOnce);
+			assert.isTrue(changeDirStub.firstCall.calledWith(name));
+			assert.isTrue(changeDirStub.calledAfter(createDirStub));
+		},
+		async 'Should get files to ender from config'() {
+			await run(helperStub, args);
+			assert.isTrue(getRenderFilesConfigStub.calledOnce);
+			assert.isTrue(renderFilesStub.calledOnce);
+			assert.isTrue(renderFilesStub.calledAfter(changeDirStub));
+		},
+		async 'Should run npmInstall'() {
+			await run(helperStub, args);
+			assert.isTrue(npmInstallStub.calledOnce);
+			assert.isTrue(npmInstallStub.calledAfter(renderFilesStub));
+		},
+		async 'Should run dojo init'() {
+			await run(helperStub, args);
+			assert.isTrue((helperStub.command.run as any).calledOnce);
+			assert.deepEqual((helperStub.command.run as any).firstCall.args, ['init', '']);
 		}
-		catch (error) {
-			assert.equal('App directory already exists', error.message);
-			assert.isTrue(existsSyncStub.calledOnce);
-			assert.isTrue(existsSyncStub.firstCall.calledWith(name));
-		}
-	},
-	async 'Should get directories to create from config'() {
-		await run(helperStub, args);
-		assert.isTrue(getDirectoryNamesStub.calledOnce);
-		assert.isTrue(createDirStub.calledOnce);
-		assert.isTrue(createDirStub.firstCall.calledWith(...dirNames));
-		assert.isTrue(createDirStub.calledAfter(existsSyncStub));
-	},
-	async 'Should change to the appname directory'() {
-		await run(helperStub, args);
-		assert.isTrue(changeDirStub.calledOnce);
-		assert.isTrue(changeDirStub.firstCall.calledWith(name));
-		assert.isTrue(changeDirStub.calledAfter(createDirStub));
-	},
-	async 'Should get files to ender from config'() {
-		await run(helperStub, args);
-		assert.isTrue(getRenderFilesConfigStub.calledOnce);
-		assert.isTrue(renderFilesStub.calledOnce);
-		assert.isTrue(renderFilesStub.calledAfter(changeDirStub));
-	},
-	async 'Should run npmInstall'() {
-		await run(helperStub, args);
-		assert.isTrue(npmInstallStub.calledOnce);
-		assert.isTrue(npmInstallStub.calledAfter(renderFilesStub));
-	},
-	async 'Should run dojo init'() {
-		await run(helperStub, args);
-		assert.isTrue((helperStub.command.run as any).calledOnce);
-		assert.deepEqual((helperStub.command.run as any).firstCall.args, [ 'init', '' ]);
-	}
 	}
 });

--- a/tests/unit/template.ts
+++ b/tests/unit/template.ts
@@ -28,13 +28,13 @@ registerSuite('template', {
 	},
 
 	tests: {
-	async 'can render ejs file'() {
-		await template(testEjsSrc, testDest, { value });
-		assert.strictEqual(writeFileStub.firstCall.args[1].trim(), value);
-	},
-	async 'write file is called with dest path'() {
-		await template(testEjsSrc, testDest, { value });
-		assert.strictEqual(writeFileStub.firstCall.args[0], testDest);
-	}
+		async 'can render ejs file'() {
+			await template(testEjsSrc, testDest, { value });
+			assert.strictEqual(writeFileStub.firstCall.args[1].trim(), value);
+		},
+		async 'write file is called with dest path'() {
+			await template(testEjsSrc, testDest, { value });
+			assert.strictEqual(writeFileStub.firstCall.args[0], testDest);
+		}
 	}
 });

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,7 @@
 {
+	"rulesDirectory": ["tslint-plugin-prettier"],
 	"rules": {
+		"prettier": true,
 		"align": false,
 		"ban": [],
 		"class-name": true,
@@ -35,9 +37,7 @@
 		"no-var-requires": false,
 		"object-literal-sort-keys": false,
 		"one-line": [ true, "check-open-brace", "check-whitespace" ],
-		"quotemark": [ true, "single" ],
 		"radix": true,
-		"semicolon": [ true, "always" ],
 		"trailing-comma": [ true, {
 			"multiline": "never",
 			"singleline": "never"
@@ -57,7 +57,6 @@
 			"property-declaration": "onespace",
 			"variable-declaration": "onespace"
 		} ],
-		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords", "allow-pascal-case" ],
-		"whitespace": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
+		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords", "allow-pascal-case" ]
 	}
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds support for `Prettier` to for code style rules and formatting. Include precommit hook that runs prettier on all `.ts` files and an npm script that runs prettier against the codebase.

Related to https://github.com/dojo/meta/issues/206
