### PR TITLE
Typo for tslib version

### DIFF
--- a/src/templates/package.json
+++ b/src/templates/package.json
@@ -9,7 +9,7 @@
     "@dojo/widget-core": "~0.6.2",
     "@dojo/widgets": "~0.4.1",
     "@dojo/i18n": "~0.4.1",
-    "tslib": "~3.8.1"
+    "tslib": "~1.8.1"
   },
   "devDependencies": {
     "@dojo/cli-build-app": "~0.1.1",


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

**Description:**

Typo for the `tslib` version in the package.json template
