### PR TITLE
Fixing typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dojo/cli-create-app",
   "version": "2.0.1-pre",
-  "description": "Command to scaffold a new command",
+  "description": "Command to scaffold a new app",
   "private": true,
   "homepage": "https://dojo.io",
   "bugs": {


### PR DESCRIPTION
Fixing the description in `package.json`. Because the description is wrong, showing the help from the cli gives the wrong description.

```
create     app         Command to scaffold a new command
```
