### PR TITLE
Ignoring .cert directory for ssl certs

### DIFF
--- a/src/templates/template-.gitignore
+++ b/src/templates/template-.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 _build/
 output/
+.cert/


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding `.cert` directory to the `.gitignore` template for the [upcoming `.cert` directories handled by `cli-create-app`](https://github.com/dojo/cli-build-app/pull/153).
