### PR TITLE
Add def files for css

### DIFF
--- a/src/templates/ts/standard/src/App.m.css.d.ts
+++ b/src/templates/ts/standard/src/App.m.css.d.ts
@@ -1,0 +1,1 @@
+export const root: string;

--- a/src/templates/ts/standard/src/widgets/styles/About.m.css.d.ts
+++ b/src/templates/ts/standard/src/widgets/styles/About.m.css.d.ts
@@ -1,0 +1,1 @@
+export const root: string;

--- a/src/templates/ts/standard/src/widgets/styles/Home.m.css.d.ts
+++ b/src/templates/ts/standard/src/widgets/styles/Home.m.css.d.ts
@@ -1,0 +1,1 @@
+export const root: string;

--- a/src/templates/ts/standard/src/widgets/styles/Menu.m.css.d.ts
+++ b/src/templates/ts/standard/src/widgets/styles/Menu.m.css.d.ts
@@ -1,0 +1,3 @@
+export const root: string;
+export const link: string;
+export const selected: string;

--- a/src/templates/ts/standard/src/widgets/styles/Profile.m.css.d.ts
+++ b/src/templates/ts/standard/src/widgets/styles/Profile.m.css.d.ts
@@ -1,0 +1,1 @@
+export const root: string;

--- a/src/templates/tsx/standard/src/App.m.css.d.ts
+++ b/src/templates/tsx/standard/src/App.m.css.d.ts
@@ -1,0 +1,1 @@
+export const root: string;

--- a/src/templates/tsx/standard/src/widgets/styles/About.m.css.d.ts
+++ b/src/templates/tsx/standard/src/widgets/styles/About.m.css.d.ts
@@ -1,0 +1,1 @@
+export const root: string;

--- a/src/templates/tsx/standard/src/widgets/styles/Home.m.css.d.ts
+++ b/src/templates/tsx/standard/src/widgets/styles/Home.m.css.d.ts
@@ -1,0 +1,1 @@
+export const root: string;

--- a/src/templates/tsx/standard/src/widgets/styles/Menu.m.css.d.ts
+++ b/src/templates/tsx/standard/src/widgets/styles/Menu.m.css.d.ts
@@ -1,0 +1,3 @@
+export const root: string;
+export const link: string;
+export const selected: string;

--- a/src/templates/tsx/standard/src/widgets/styles/Profile.m.css.d.ts
+++ b/src/templates/tsx/standard/src/widgets/styles/Profile.m.css.d.ts
@@ -1,0 +1,1 @@
+export const root: string;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Add the type def files for the css to the templates.