### PR TITLE
Provide self contained npm scripts

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -17,6 +17,16 @@ export default async function(helper: Helper, args: CreateAppArgs) {
 	const isSkeleton = args.skeleton;
 	const isTsx = args.tsx;
 
+	const scripts = {
+		dev: 'dojo build --mode dev --watch file --serve',
+		build: 'dojo build --mode dist',
+		buildDev: `dojo build --mode dev`,
+		test: 'dojo test',
+		testUnit: 'dojo build --mode unit && dojo test --unit --config local',
+		testFunctional: 'dojo build --mode functional && dojo test --functional --config local',
+		testAll: 'dojo build --mode unit && dojo build --mode functional && dojo test --all --config local'
+	};
+
 	console.info(chalk.underline(`Creating your new app: ${appName}\n`));
 
 	if (existsSync(appName)) {
@@ -29,7 +39,7 @@ export default async function(helper: Helper, args: CreateAppArgs) {
 	changeDir(appName);
 
 	console.info(chalk.underline('\nCreating Files'));
-	helper.command.renderFiles(getRenderFilesConfig(isSkeleton, isTsx), { appName });
+	helper.command.renderFiles(getRenderFilesConfig(isSkeleton, isTsx), { appName, scripts });
 
 	console.info(chalk.underline('\nRunning npm install'));
 	await npmInstall();

--- a/src/templates/ts/skeleton/README.md
+++ b/src/templates/ts/skeleton/README.md
@@ -4,29 +4,37 @@ This project was generated with the [Dojo CLI](https://github.com/dojo/cli) & [D
 
 ## Build
 
-Run `dojo build --mode dist` (the `mode` option defaults to `dist`) to create a production build for the project. The built artifacts will be stored in the `output/dist` directory.
+Run `npm run build` or `dojo build --mode dist` (the `mode` option defaults to `dist`) to create a production build for the project. The built artifacts will be stored in the `output/dist` directory.
 
 ## Development Build
 
-Run `dojo build --mode dev` to create a development build for the project. The built artifacts will be stored in the `output/dev` directory.
+Run `npm run build:dev` or `dojo build --mode dev` to create a development build for the project. The built artifacts will be stored in the `output/dev` directory.
 
 ## Development server
 
-Run `dojo build --mode dev --watch memory --serve` to create an in memory development build and start a development server with hot reload. By default the server runs on port `9999`, navigate to `http://localhost:9999/`.
+Run `npm run dev` or `dojo build --mode dev --watch file --serve` to create a development build and start a development server. By default the server runs on port `9999`, navigate to `http://localhost:9999/`.
 
-To change the port of the development use the `--port` option.
+To change the port of the development server use the `--port` option on the `dojo build` command.
+
+To create an in memory development build and start a development server with hot reload, switch the `--watch` option to `memory`.
 
 ## Running unit tests
 
-To run units tests in node only use `dojo test` which uses JIT (just in time) compilation.
+To run units tests in node only use `npm run test` or `dojo test` which uses JIT (just in time) compilation.
 
-To run the unit tests against built bundles, first the run a test build with `dojo build --mode unit`. The build test artifacts are written to the `output/tests/unit` directory.
+To run the unit tests against built bundles, run `npm run test:unit`.
 
-Then `dojo test -c local` to run the projects unit tests. These tests are located in the `tests/unit` directory. The `--watch` options can be used with the test build which means that `dojo test` can be re-run without needing to re-build the full application each time.
+To be re-run the unit tests without needing to re-build the full application each time, first build the app with `--mode unit` and the `--watch` option, `dojo build --mode unit --watch`. Then run `dojo test --config local` to run the unit tests as needed.
+
+The build test artifacts are written to the `output/tests/unit` directory. These tests are located in the `tests/unit` directory.
 
 ## Running functional tests
 
-To run the functional tests, first the run a test build with `dojo build --mode functional` and then `dojo test -f` to run the projects functional tests. These tests are located in the `tests/functional` directory.
+To run the functional tests, run `npm run test:functional`. These tests are located in the `tests/functional` directory.
+
+## Running unit and functional tests together
+
+To run both unit and functional tests as the same time, run `npm run test:all`.
 
 ## Further help
 

--- a/src/templates/ts/skeleton/package.json
+++ b/src/templates/ts/skeleton/package.json
@@ -1,11 +1,21 @@
 {
   "name": "<%- appName %>",
   "version": "1.0.0",
+  "scripts": {
+    "dev": "<%- scripts.dev %>",
+    "build": "<%- scripts.build %>",
+    "build:dev": "<%- scripts.buildDev %>",
+    "test": "<%- scripts.test %>",
+    "test:unit": "<%- scripts.testUnit %>",
+    "test:functional": "<%- scripts.testFunctional %>",
+    "test:all": "<%- scripts.testAll %>"
+  },
   "dependencies": {
     "@dojo/framework": "^4.0.0",
     "tslib": "~1.8.1"
   },
   "devDependencies": {
+    "@dojo/cli": "^4.0.0",
     "@dojo/cli-build-app": "^4.0.0",
     "@dojo/cli-test-intern": "^4.0.0",
     "@types/node": "~9.6.5",

--- a/src/templates/ts/standard/README.md
+++ b/src/templates/ts/standard/README.md
@@ -4,29 +4,37 @@ This project was generated with the [Dojo CLI](https://github.com/dojo/cli) & [D
 
 ## Build
 
-Run `dojo build --mode dist` (the `mode` option defaults to `dist`) to create a production build for the project. The built artifacts will be stored in the `output/dist` directory.
+Run `npm run build` or `dojo build --mode dist` (the `mode` option defaults to `dist`) to create a production build for the project. The built artifacts will be stored in the `output/dist` directory.
 
 ## Development Build
 
-Run `dojo build --mode dev` to create a development build for the project. The built artifacts will be stored in the `output/dev` directory.
+Run `npm run build:dev` or `dojo build --mode dev` to create a development build for the project. The built artifacts will be stored in the `output/dev` directory.
 
 ## Development server
 
-Run `dojo build --mode dev --watch memory --serve` to create an in memory development build and start a development server with hot reload. By default the server runs on port `9999`, navigate to `http://localhost:9999/`.
+Run `npm run dev` or `dojo build --mode dev --watch file --serve` to create a development build and start a development server. By default the server runs on port `9999`, navigate to `http://localhost:9999/`.
 
-To change the port of the development use the `--port` option.
+To change the port of the development server use the `--port` option on the `dojo build` command.
+
+To create an in memory development build and start a development server with hot reload, switch the `--watch` option to `memory`.
 
 ## Running unit tests
 
-To run units tests in node only use `dojo test` which uses JIT (just in time) compilation.
+To run units tests in node only use `npm run test` or `dojo test` which uses JIT (just in time) compilation.
 
-To run the unit tests against built bundles, first the run a test build with `dojo build --mode unit`. The build test artifacts are written to the `output/tests/unit` directory.
+To run the unit tests against built bundles, run `npm run test:unit`.
 
-Then `dojo test -c local` to run the projects unit tests. These tests are located in the `tests/unit` directory. The `--watch` options can be used with the test build which means that `dojo test` can be re-run without needing to re-build the full application each time.
+To be re-run the unit tests without needing to re-build the full application each time, first build the app with `--mode unit` and the `--watch` option, `dojo build --mode unit --watch`. Then run `dojo test --config local` to run the unit tests as needed.
+
+The build test artifacts are written to the `output/tests/unit` directory. These tests are located in the `tests/unit` directory.
 
 ## Running functional tests
 
-To run the functional tests, first the run a test build with `dojo build --mode functional` and then `dojo test -f` to run the projects functional tests. These tests are located in the `tests/functional` directory.
+To run the functional tests, run `npm run test:functional`. These tests are located in the `tests/functional` directory.
+
+## Running unit and functional tests together
+
+To run both unit and functional tests as the same time, run `npm run test:all`.
 
 ## Further help
 

--- a/src/templates/ts/standard/package.json
+++ b/src/templates/ts/standard/package.json
@@ -1,6 +1,15 @@
 {
   "name": "<%- appName %>",
   "version": "1.0.0",
+  "scripts": {
+    "dev": "<%- scripts.dev %>",
+    "build": "<%- scripts.build %>",
+    "build:dev": "<%- scripts.buildDev %>",
+    "test": "<%- scripts.test %>",
+    "test:unit": "<%- scripts.testUnit %>",
+    "test:functional": "<%- scripts.testFunctional %>",
+    "test:all": "<%- scripts.testAll %>"
+  },
   "dependencies": {
     "@dojo/framework": "^4.0.0",
     "@dojo/themes": "^4.0.0",
@@ -8,6 +17,7 @@
     "tslib": "~1.8.1"
   },
   "devDependencies": {
+    "@dojo/cli": "^4.0.0",
     "@dojo/cli-build-app": "^4.0.0",
     "@dojo/cli-test-intern": "^4.0.0",
     "@types/node": "~9.6.5",

--- a/src/templates/tsx/skeleton/README.md
+++ b/src/templates/tsx/skeleton/README.md
@@ -4,29 +4,37 @@ This project was generated with the [Dojo CLI](https://github.com/dojo/cli) & [D
 
 ## Build
 
-Run `dojo build --mode dist` (the `mode` option defaults to `dist`) to create a production build for the project. The built artifacts will be stored in the `output/dist` directory.
+Run `npm run build` or `dojo build --mode dist` (the `mode` option defaults to `dist`) to create a production build for the project. The built artifacts will be stored in the `output/dist` directory.
 
 ## Development Build
 
-Run `dojo build --mode dev` to create a development build for the project. The built artifacts will be stored in the `output/dev` directory.
+Run `npm run build:dev` or `dojo build --mode dev` to create a development build for the project. The built artifacts will be stored in the `output/dev` directory.
 
 ## Development server
 
-Run `dojo build --mode dev --watch memory --serve` to create an in memory development build and start a development server with hot reload. By default the server runs on port `9999`, navigate to `http://localhost:9999/`.
+Run `npm run dev` or `dojo build --mode dev --watch file --serve` to create a development build and start a development server. By default the server runs on port `9999`, navigate to `http://localhost:9999/`.
 
-To change the port of the development use the `--port` option.
+To change the port of the development server use the `--port` option on the `dojo build` command.
+
+To create an in memory development build and start a development server with hot reload, switch the `--watch` option to `memory`.
 
 ## Running unit tests
 
-To run units tests in node only use `dojo test` which uses JIT (just in time) compilation.
+To run units tests in node only use `npm run test` or `dojo test` which uses JIT (just in time) compilation.
 
-To run the unit tests against built bundles, first the run a test build with `dojo build --mode unit`. The build test artifacts are written to the `output/tests/unit` directory.
+To run the unit tests against built bundles, run `npm run test:unit`.
 
-Then `dojo test -c local` to run the projects unit tests. These tests are located in the `tests/unit` directory. The `--watch` options can be used with the test build which means that `dojo test` can be re-run without needing to re-build the full application each time.
+To be re-run the unit tests without needing to re-build the full application each time, first build the app with `--mode unit` and the `--watch` option, `dojo build --mode unit --watch`. Then run `dojo test --config local` to run the unit tests as needed.
+
+The build test artifacts are written to the `output/tests/unit` directory. These tests are located in the `tests/unit` directory.
 
 ## Running functional tests
 
-To run the functional tests, first the run a test build with `dojo build --mode functional` and then `dojo test -f` to run the projects functional tests. These tests are located in the `tests/functional` directory.
+To run the functional tests, run `npm run test:functional`. These tests are located in the `tests/functional` directory.
+
+## Running unit and functional tests together
+
+To run both unit and functional tests as the same time, run `npm run test:all`.
 
 ## Further help
 

--- a/src/templates/tsx/skeleton/package.json
+++ b/src/templates/tsx/skeleton/package.json
@@ -1,11 +1,21 @@
 {
   "name": "<%- appName %>",
   "version": "1.0.0",
+  "scripts": {
+    "dev": "<%- scripts.dev %>",
+    "build": "<%- scripts.build %>",
+    "build:dev": "<%- scripts.buildDev %>",
+    "test": "<%- scripts.test %>",
+    "test:unit": "<%- scripts.testUnit %>",
+    "test:functional": "<%- scripts.testFunctional %>",
+    "test:all": "<%- scripts.testAll %>"
+  },
   "dependencies": {
     "@dojo/framework": "^4.0.0",
     "tslib": "~1.8.1"
   },
   "devDependencies": {
+    "@dojo/cli": "^4.0.0",
     "@dojo/cli-build-app": "^4.0.0",
     "@dojo/cli-test-intern": "^4.0.0",
     "@types/node": "~9.6.5",

--- a/src/templates/tsx/standard/README.md
+++ b/src/templates/tsx/standard/README.md
@@ -4,29 +4,37 @@ This project was generated with the [Dojo CLI](https://github.com/dojo/cli) & [D
 
 ## Build
 
-Run `dojo build --mode dist` (the `mode` option defaults to `dist`) to create a production build for the project. The built artifacts will be stored in the `output/dist` directory.
+Run `npm run build` or `dojo build --mode dist` (the `mode` option defaults to `dist`) to create a production build for the project. The built artifacts will be stored in the `output/dist` directory.
 
 ## Development Build
 
-Run `dojo build --mode dev` to create a development build for the project. The built artifacts will be stored in the `output/dev` directory.
+Run `npm run build:dev` or `dojo build --mode dev` to create a development build for the project. The built artifacts will be stored in the `output/dev` directory.
 
 ## Development server
 
-Run `dojo build --mode dev --watch memory --serve` to create an in memory development build and start a development server with hot reload. By default the server runs on port `9999`, navigate to `http://localhost:9999/`.
+Run `npm run dev` or `dojo build --mode dev --watch file --serve` to create a development build and start a development server. By default the server runs on port `9999`, navigate to `http://localhost:9999/`.
 
-To change the port of the development use the `--port` option.
+To change the port of the development server use the `--port` option on the `dojo build` command.
+
+To create an in memory development build and start a development server with hot reload, switch the `--watch` option to `memory`.
 
 ## Running unit tests
 
-To run units tests in node only use `dojo test` which uses JIT (just in time) compilation.
+To run units tests in node only use `npm run test` or `dojo test` which uses JIT (just in time) compilation.
 
-To run the unit tests against built bundles, first the run a test build with `dojo build --mode unit`. The build test artifacts are written to the `output/tests/unit` directory.
+To run the unit tests against built bundles, run `npm run test:unit`.
 
-Then `dojo test -c local` to run the projects unit tests. These tests are located in the `tests/unit` directory. The `--watch` options can be used with the test build which means that `dojo test` can be re-run without needing to re-build the full application each time.
+To be re-run the unit tests without needing to re-build the full application each time, first build the app with `--mode unit` and the `--watch` option, `dojo build --mode unit --watch`. Then run `dojo test --config local` to run the unit tests as needed.
+
+The build test artifacts are written to the `output/tests/unit` directory. These tests are located in the `tests/unit` directory.
 
 ## Running functional tests
 
-To run the functional tests, first the run a test build with `dojo build --mode functional` and then `dojo test -f` to run the projects functional tests. These tests are located in the `tests/functional` directory.
+To run the functional tests, run `npm run test:functional`. These tests are located in the `tests/functional` directory.
+
+## Running unit and functional tests together
+
+To run both unit and functional tests as the same time, run `npm run test:all`.
 
 ## Further help
 

--- a/src/templates/tsx/standard/package.json
+++ b/src/templates/tsx/standard/package.json
@@ -1,6 +1,15 @@
 {
   "name": "<%- appName %>",
   "version": "1.0.0",
+  "scripts": {
+    "dev": "<%- scripts.dev %>",
+    "build": "<%- scripts.build %>",
+    "build:dev": "<%- scripts.buildDev %>",
+    "test": "<%- scripts.test %>",
+    "test:unit": "<%- scripts.testUnit %>",
+    "test:functional": "<%- scripts.testFunctional %>",
+    "test:all": "<%- scripts.testAll %>"
+  },
   "dependencies": {
     "@dojo/framework": "^4.0.0",
     "@dojo/themes": "^4.0.0",
@@ -8,6 +17,7 @@
     "tslib": "~1.8.1"
   },
   "devDependencies": {
+    "@dojo/cli": "^4.0.0",
     "@dojo/cli-build-app": "^4.0.0",
     "@dojo/cli-test-intern": "^4.0.0",
     "@types/node": "~9.6.5",


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds in dev, build and test scripts, along with adding @dojo/cli as a dev dependency, to the package.json templates.

Resolves #154 
