### PR TITLE
Add dir/charset to HTML templates

### DIFF
--- a/src/templates/ts/skeleton/src/index.html
+++ b/src/templates/ts/skeleton/src/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-<html lang="en-us">
+<html lang="en-us" dir="ltr">
 <head>
+	<meta charset="utf-8">
 	<title><%= appName %></title>
 	<meta name="theme-color" content="#222127">
 	<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/templates/ts/standard/src/index.html
+++ b/src/templates/ts/standard/src/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-<html lang="en-us">
+<html lang="en-us" dir="ltr">
 <head>
+	<meta charset="utf-8">
 	<title><%= appName %></title>
 	<meta name="theme-color" content="#222127">
 	<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/templates/tsx/skeleton/src/index.html
+++ b/src/templates/tsx/skeleton/src/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-<html lang="en-us">
+<html lang="en-us" dir="ltr">
 <head>
+	<meta charset="utf-8">
 	<title><%= appName %></title>
 	<meta name="theme-color" content="#222127">
 	<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/templates/tsx/standard/src/index.html
+++ b/src/templates/tsx/standard/src/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-<html lang="en-us">
+<html lang="en-us" dir="ltr">
 <head>
+	<meta charset="utf-8">
 	<title><%= appName %></title>
 	<meta name="theme-color" content="#222127">
 	<meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Update the `<html>` tag with the default `dir="ltr"` attribute and add the missing `<meta charset="utf-8">` tag to the template `<head>`s.

Resolves #168 